### PR TITLE
Add ability to read principal names from a wordlist file

### DIFF
--- a/iam_principal_enumerator/util/__init__.py
+++ b/iam_principal_enumerator/util/__init__.py
@@ -1,5 +1,7 @@
 import random
 import string
+from pathlib import Path
+from typing import Any, Generator
 
 
 def generate_random_string(length=8):
@@ -11,3 +13,25 @@ def generate_random_string(length=8):
     """
     characters = string.ascii_letters + string.digits
     return "".join(random.choice(characters) for _ in range(length))
+
+
+def is_valid_file(filename: Path):
+    """
+    Check if the given file exists.
+
+    :param filename: Path to the file
+    :return: True if file exists, False otherwise
+    """
+    return filename.is_file()
+
+
+def read_lines_from_file(filename: Path) -> Generator[str, Any, None]:
+    """
+    Read lines from a file.
+
+    :param filename: Path to the file
+    :yield: Lines from the file, stripped of whitespace
+    """
+    with open(filename, "r") as f:
+        for line in f:
+            yield line.strip()

--- a/principal_names.txt
+++ b/principal_names.txt
@@ -1,0 +1,17 @@
+admin
+administrator
+deploy
+deploy-dev
+deployer
+deployer-dev
+deployer-prod
+deploy-prod
+dev
+dev
+dev-deploy
+developer
+gitlab-ci
+gitlab-runner
+it-admin
+prod
+prod-deploy


### PR DESCRIPTION
Adds functionality to read principal names from a text file specified by the `-w` or `--wordlist` CLI arguments. A default, small wordlist file is provided for sample usage.

Wordlist files will be validated to ensure they exist, and principal names read line by line.